### PR TITLE
docs: 로컬 실행 단계에 DB 초기화 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,14 +58,24 @@ pnpm i
 cp .env.example .env
 # .env 파일 수정 (PORT, DATABASE_URL 등)
 
-# 3. 개발 모드 (ts-node + HMR)
+# 3. 데이터베이스 초기화
+pnpm db:push:dev
+pnpm db:seed:dev
+
+# 4. 개발 모드 (ts-node + HMR)
 pnpm dev
 
-# 4. Swagger 문서
+# 5. Swagger 문서
 # -> http://localhost:4000/docs
 ```
 
 > 기본 포트 **4000**
+
+필요할 경우 Redis 데이터를 초기화하려면 아래 명령어를 실행합니다.
+
+```bash
+pnpm redis:reset # scripts/redis-reset.ts 실행
+```
 
 ---
 


### PR DESCRIPTION
## 변경 내용
- README의 로컬 실행 섹션에 데이터베이스 초기화 명령어(`pnpm db:push:dev`, `pnpm db:seed:dev`)를 추가했습니다.
- 필요 시 Redis 데이터를 초기화할 수 있도록 `pnpm redis:reset` 사용법을 안내했습니다.

## 테스트 결과
- `pnpm test` 실행 시 네트워크 오류로 패키지 설치에 실패했습니다.
