### PR TITLE
FEAT: Hot Index

### DIFF
--- a/src/jobs/keyword.job.ts
+++ b/src/jobs/keyword.job.ts
@@ -1,0 +1,41 @@
+import fp from 'fastify-plugin';
+import { AsyncTask, CronJob } from 'toad-scheduler';
+
+const KEY_ZSET = 'live:kw';
+const KEY_HASH = 'live:kw:index';
+
+export default fp(app => {
+  const task = new AsyncTask(
+    'normalize-keyword-index',
+    async () => {
+      const raw = await app.redis.zrevrange(KEY_ZSET, 0, 4, 'WITHSCORES');
+      const freq: [string, number][] = [];
+      for (let i = 0; i < raw.length; i += 2) freq.push([raw[i], Number(raw[i + 1])]);
+
+      if (freq.length === 0) return;
+
+      const max = Math.max(...freq.map(([, s]) => s));
+
+      const multi = app.redis.multi();
+      freq.forEach(([word, score]) => {
+        const index = max === 0 ? 0 : Math.round((score / max) * 100);
+        multi.hset(KEY_HASH, word, index);
+      });
+
+      await multi.exec();
+      app.log.debug({ freq, max }, `[keyword.job] hash 업데이트 완료 (max=${max})`);
+    },
+    err => app.log.error(err, '[keyword.job] 작업 실패'),
+  );
+
+  app.scheduler.addCronJob(
+    new CronJob(
+      {
+        cronExpression: '*/1 * * * *',
+      },
+      task,
+    ),
+  );
+
+  app.log.info('[keyword.job] normalize-keyword-index 등록');
+});

--- a/src/routes/comment/comment.route.ts
+++ b/src/routes/comment/comment.route.ts
@@ -18,6 +18,8 @@ export default fp(app => {
         params: DebateParam,
         querystring: CommentListQuery,
         response: { 200: ResCommentList },
+        summary: '댓글 목록',
+        tags: ['Comment'],
       },
     },
     async (req, reply) => reply.ok(await getCommentList(req)),
@@ -29,6 +31,8 @@ export default fp(app => {
       schema: {
         body: CommentBody,
         response: { 200: ResCommentOk },
+        summary: '댓글 생성',
+        tags: ['Comment'],
       },
     },
     async (req, reply) => reply.ok(await addComment(req), '댓글이 등록되었습니다.'),
@@ -40,6 +44,8 @@ export default fp(app => {
       schema: {
         params: CommentLikeParam,
         response: { 200: ResCommentOk },
+        summary: '댓글 좋아요',
+        tags: ['Comment'],
       },
     },
     async (req, reply) => reply.ok(await likeComment(req)),

--- a/src/routes/debate/debate.route.ts
+++ b/src/routes/debate/debate.route.ts
@@ -17,6 +17,8 @@ export default fp(app => {
       schema: {
         querystring: DebateListQuery,
         response: { 200: ResDebateList },
+        summary: '토론 목록',
+        tags: ['Debate'],
       },
     },
     async (req, reply) => {
@@ -31,6 +33,8 @@ export default fp(app => {
       schema: {
         params: DebateIdParam,
         response: { 200: ResDebateDetail },
+        summary: '토론 디테일',
+        tags: ['Debate'],
       },
     },
     async (req, reply) => {
@@ -45,6 +49,8 @@ export default fp(app => {
       schema: {
         body: CreateDebateBody,
         response: { 201: ResCreateDebate },
+        summary: '토론 생성',
+        tags: ['Debate'],
       },
     },
     async (req, reply) => {

--- a/src/routes/keyword/keyword.route.ts
+++ b/src/routes/keyword/keyword.route.ts
@@ -1,10 +1,11 @@
 import { FastifyInstance } from 'fastify';
+import fp from 'fastify-plugin';
 
 import { apiFail } from '@/schemas/common.schema';
 import { LiveKeyword, LiveKeywordResponse } from '@/schemas/keyword.schema';
 import { getLiveKeywords } from '@/services/keyword.service';
 
-const route = (app: FastifyInstance) => {
+export default fp((app: FastifyInstance) => {
   app.get(
     '/keywords/live',
     {
@@ -60,6 +61,4 @@ const route = (app: FastifyInstance) => {
 
     req.raw.on('close', () => clearInterval(timer));
   });
-};
-
-export default route;
+});

--- a/src/routes/keyword/keyword.route.ts
+++ b/src/routes/keyword/keyword.route.ts
@@ -1,0 +1,65 @@
+import { FastifyInstance } from 'fastify';
+
+import { apiFail } from '@/schemas/common.schema';
+import { LiveKeyword, LiveKeywordResponse } from '@/schemas/keyword.schema';
+import { getLiveKeywords } from '@/services/keyword.service';
+
+const route = (app: FastifyInstance) => {
+  app.get(
+    '/keywords/live',
+    {
+      schema: {
+        response: {
+          200: LiveKeywordResponse,
+          500: apiFail,
+        },
+        summary: '실시간 키워드',
+        tags: ['Keyword'],
+      },
+    },
+    async (_req, reply) => {
+      try {
+        const keywords = await getLiveKeywords();
+        return reply.send({
+          success: true,
+          message: '',
+          data: { keywords },
+        });
+      } catch (e) {
+        app.log.error(e);
+        return reply.status(500).send({
+          success: false,
+          code: 'INTERNAL',
+          message: 'keywords fetch failed',
+          data: null,
+        });
+      }
+    },
+  );
+  app.get('/keywords/live/stream', async (req, reply) => {
+    reply.raw.setHeader('Content-Type', 'text/event-stream');
+    reply.raw.setHeader('Cache-Control', 'no-cache');
+    reply.raw.setHeader('Connection', 'keep-alive');
+
+    const push = (keywords: LiveKeyword[]) =>
+      reply.raw.write(
+        `data: ${JSON.stringify({
+          success: true,
+          message: '',
+          data: { keywords },
+        })}\n\n`,
+      );
+
+    push(await getLiveKeywords());
+
+    const timer = setInterval(() => {
+      getLiveKeywords()
+        .then(push)
+        .catch(err => app.log.error(err));
+    }, 5000);
+
+    req.raw.on('close', () => clearInterval(timer));
+  });
+};
+
+export default route;

--- a/src/schemas/keyword.schema.ts
+++ b/src/schemas/keyword.schema.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { apiSuccess } from './common.schema.js';
+
+export const LiveKeyword = z.object({
+  word: z.string(),
+  score: z.number().int().nonnegative(),
+  index: z.number().int().min(0).max(100),
+});
+export type LiveKeyword = z.infer<typeof LiveKeyword>;
+
+export const LiveKeywordSchema = z.object({
+  keywords: z.array(LiveKeyword),
+});
+export const LiveKeywordResponse = apiSuccess(LiveKeywordSchema);
+export type LiveKeywordResponse = z.infer<typeof LiveKeywordResponse>;

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,6 +10,7 @@ import securityPlugin from '@/plugins/security';
 import swaggerPlugin from '@/plugins/swagger';
 
 import hotScoreJob from './jobs/hot-score.job.js';
+import keywordJob from './jobs/keyword.job.js';
 import statusSwitchJob from './jobs/status-switch.job.js';
 import syncCommentLikesJob from './jobs/sync-comment-likes.job.js';
 import syncViewsJob from './jobs/sync-views.job.js';
@@ -47,6 +48,7 @@ export async function buildServer() {
   await app.register(statusSwitchJob);
   await app.register(hotScoreJob);
   await app.register(syncCommentLikesJob);
+  await app.register(keywordJob);
 
   /** Error Helper */
   await app.register(sensible);

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import errorHandler from './plugins/error-handler.js';
 import responsePlugin from './plugins/response.js';
 import commentRoute from './routes/comment/comment.route.js';
 import debateRoute from './routes/debate/debate.route.js';
+import keywordRoute from './routes/keyword/keyword.route.js';
 
 export async function buildServer() {
   /**
@@ -74,6 +75,7 @@ export async function buildServer() {
   app.get('/health/redis', async () => ({ pong: await app.redis.ping() }));
   app.register(debateRoute);
   app.register(commentRoute);
+  app.register(keywordRoute);
 
   /** Error Handler */
   await app.register(errorHandler);

--- a/src/services/keyword.service.ts
+++ b/src/services/keyword.service.ts
@@ -1,0 +1,28 @@
+import { redis } from '@/libs/redis/index';
+import { LiveKeyword } from '@/schemas/keyword.schema';
+
+const KEY_ZSET = 'live:kw';
+const KEY_HASH = 'live:kw:index';
+
+export async function getLiveKeywords(limit = 5): Promise<LiveKeyword[]> {
+  const raw = await redis.zrevrange(KEY_ZSET, 0, limit - 1, 'WITHSCORES');
+  if (raw.length === 0) return [];
+
+  const words: string[] = [];
+  const list: { word: string; score: number }[] = [];
+  for (let i = 0; i < raw.length; i += 2) {
+    const word = raw[i];
+    const score = Number(raw[i + 1]);
+    words.push(word);
+    list.push({ word, score });
+  }
+
+  const idxArr = await redis.hmget(KEY_HASH, ...words);
+
+  return list.map((kw, i) =>
+    LiveKeyword.parse({
+      ...kw,
+      index: Number(idxArr[i] ?? 0),
+    }),
+  );
+}


### PR DESCRIPTION
## 개요
- 실시간 키워드마다 “얼마나 뜨거운가”를 % 값(0-100)으로 시각화하려면 원본 빈도 점수를 정규화 Hot Index 로 변환해 API에 포함해야 한다.

## 변경 사항

- keyword job 추가
- keyword service, route 추가
- swagger에 반영

## 스크린샷 / 로그

| BEFORE | AFTER |
| ------ | ----- |
|        |       |

## 체크리스트

- [ ] 로컬에서 `pnpm test` 통과
- [ ] 변경된 API 명세 README 업데이트
